### PR TITLE
Fix CitationQueryEngine: excluded_llm_metadata_keys are not respected

### DIFF
--- a/llama_index/query_engine/citation_query_engine.py
+++ b/llama_index/query_engine/citation_query_engine.py
@@ -196,6 +196,7 @@ class CitationQueryEngine(BaseQueryEngine):
                     NodeWithScore(
                         node=TextNode(
                             text=text,
+                            excluded_llm_metadata_keys=node.node.excluded_llm_metadata_keys or [],
                             metadata=node.node.metadata or {},
                             relationships=node.node.relationships or {},
                         ),


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
The CitationQueryEngine does not exclude metadata keys, when some are set. This is due to the fact, that _create_citation_nodes creates new TextNode instances, which do not have the property of the old node.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes